### PR TITLE
Add country placeholder to the default footer

### DIFF
--- a/footers/README.md
+++ b/footers/README.md
@@ -38,7 +38,7 @@ file using the following commands:
 \usepackage{fancyhdr}
 \fancyhf{}
 \renewcommand{\headrulewidth}{0pt}
-\fancyfoot[CO]{\thepage \\ \textit{\small Proceedings of the XXth Workshop on the Semantics and Pragmatics of Dialogue, Month, XX–XX, YEAR, PLACE.}}
+\fancyfoot[CO]{\thepage \\ \textit{\small Proceedings of the XXth Workshop on the Semantics and Pragmatics of Dialogue, Month, XX–XX, YEAR, CITY, COUNTRY.}}
 \pagestyle{fancy}
 ```
 (adapted from [here](https://askubuntu.com/questions/712691/batch-add-header-footer-to-pdf-files)).

--- a/footers/footer/footer_page.tex
+++ b/footers/footer/footer_page.tex
@@ -4,7 +4,7 @@
 % To add it to a new year, update:
 % - the edition (25th) to the corresponding one
 % - the date (September 20-22, 2021) 
-% the location (Potsdam / The Internet)
+% - the location (Potsdam, Germany / The Internet)
 
 % For consistency, please keep the rest as it is.
 
@@ -25,7 +25,7 @@
 \begin{document}
 	
 	\fancyfoot[CO]{\textit{Proceedings of the 25th Workshop on the Semantics and Pragmatics of Dialogue, 
-			September 20–22, 2021, Potsdam / The Internet.}}
+			September 20–22, 2021, Potsdam, Germany / The Internet.}}
 	
 	\newpage\null\thispagestyle{fancy}\newpage
 	


### PR DESCRIPTION
Some of the previous footers did not include the country. It is better to add it and be consistent in upcoming editions.
These two commits update the default footers with the indication to include the country.